### PR TITLE
add require version

### DIFF
--- a/lib/chef/knife/softlayer_base.rb
+++ b/lib/chef/knife/softlayer_base.rb
@@ -6,6 +6,7 @@
 #
 
 require 'chef/knife'
+require 'knife-softlayer/version'
 
 class Chef
   class Knife


### PR DESCRIPTION
fix below error

% knife softlayer
/home/d-higuchi/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/knife-softlayer-0.0.3/lib/chef/knife/softlayer_base.rb:14:in `module:SoftlayerBase': uninitialized constant Knife (NameError)
