### PR TITLE
Fixing bug where --private-network-only option makes sshable? fail constantly, triggering an eventual timeout

### DIFF
--- a/lib/chef/knife/softlayer_server_create.rb
+++ b/lib/chef/knife/softlayer_server_create.rb
@@ -289,6 +289,9 @@ class Chef
 
         puts ui.color("Launching SoftLayer VM, this may take a few minutes.", :green)
         instance = connection.servers.create(opts)
+        if config[:private_network_only]
+          instance.ssh_ip_address = Proc.new {|server| server.private_ip_address }
+        end
         progress Proc.new { instance.wait_for { ready? and sshable? } }
         putc("\n")
 


### PR DESCRIPTION
This fixes #14 
