### PR TITLE
server list subcommand and destroy fixes

### DIFF
--- a/lib/chef/knife/softlayer_server_list.rb
+++ b/lib/chef/knife/softlayer_server_list.rb
@@ -1,0 +1,27 @@
+require 'chef/knife/softlayer_base'
+require 'chef/search/query'
+require 'chef/api_client'
+
+class Chef
+  class Knife
+    class SoftlayerServerList < Knife
+
+      include Knife::SoftlayerBase
+
+      banner 'knife softlayer server list (options)'
+
+      ##
+      # Run the procedure to list all of the Softlayer VM's
+      # @return [nil]
+      def run
+
+        $stdout.sync = true
+        fmt = "%-20s %-8s %-15s %-15s %-10s"
+        puts ui.color(sprintf(fmt, "Name", "Location", "Public IP", "Private IP", "Status"), :green)
+        connection.servers.each do |server|
+          puts sprintf fmt, server.name, server.datacenter, server.public_ip_address, server.private_ip_address, server.created_at ? 'Running' : 'Starting'
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/knife/softlayer_server_relaunch.rb
+++ b/lib/chef/knife/softlayer_server_relaunch.rb
@@ -100,8 +100,6 @@ class Chef
   end
 end
 
-||||||| merged common ancestors
-=======
 #
 # Author:: Matt Eldridge (<matt.eldridge@us.ibm.com>)
 # © Copyright IBM Corporation 2014.


### PR DESCRIPTION
1) add server list subcommand
2) rewrite server destroy to fetch the server list from softlayer first
   rather than the chef node list so that half baked instances and other
   chef mishaps still reap the server instance on the softlayer side.
3) fix merge detritus in relaunch