### PR TITLE
Remove Ruby 1.9.3 from travis testing matix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ script: bundle exec rspec spec
 matrix:
   fast_finish: true
   include:
-    - rvm: 1.9.3
-      gemfile: Gemfile
     - rvm: 2.0.0
       gemfile: Gemfile
     - rvm: 2.1.0


### PR DESCRIPTION
Ruby 1.9.3 is deprecated in Rubyland. Also, newer versions of Chef
require Ruby >=2.0 so some gems will fail to install.