### PR TITLE
New user_data option when creating instance

### DIFF
--- a/examples/server.md
+++ b/examples/server.md
@@ -38,7 +38,8 @@ user@localhost> cat /Users/user/bootstrap.json
   "run-list": "recipe[redis],recipe[rbenv],recipe[apt]",
   "ssh-keys": "73148",
   "identity-file": "/Users/user/.ssh/my_softlayer_key_rsa",
-  "image-id": "23f7f05f-3657-4330-8772-329ed2e816bc"
+  "image-id": "23f7f05f-3657-4330-8772-329ed2e816bc",
+  "user_data": "first_boot=disabled"
 }
 
 user@localhost> knife softlayer server create --from-file /Users/user/bootstrap.json

--- a/lib/chef/knife/softlayer_server_create.rb
+++ b/lib/chef/knife/softlayer_server_create.rb
@@ -244,6 +244,11 @@ class Chef
                Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new
              }
 
+      option :user_data,
+             :short => "-u USERDATA",
+             :long => "--user-data USERDATA",
+             :description => "Optional user data to pass on to SoftLayer compute instance"
+
       require 'chef/knife/bootstrap'
       # Make the base bootstrap options available on topo bootstrap
       self.options = (Chef::Knife::Bootstrap.options).merge(self.options)
@@ -283,7 +288,8 @@ class Chef
             :private_vlan => nil,
             :image_id => nil,
             :private_network_only => nil,
-            #:tags => nil
+            #:tags => nil,
+            :user_data => nil
         }
 
 


### PR DESCRIPTION
Allow user to provide user_data as a bootstrap option. Some of our images require user_data for their first boot sequence.

I'm an IBM employee (Aspera, iank@us.ibm.com) so I'm not sure where that puts me on the CLA front. Let me know.