### PR TITLE
Bumping lib dependency version

### DIFF
--- a/knife-softlayer.gemspec
+++ b/knife-softlayer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog-softlayer", "~> 0.3.30"
+  spec.add_dependency "fog-softlayer", "~> 1.1.0"
   spec.add_dependency "knife-windows", "> 0.5.12"
   spec.add_dependency "net-ssh", "> 2.8.0"
 

--- a/lib/knife-softlayer/version.rb
+++ b/lib/knife-softlayer/version.rb
@@ -7,6 +7,6 @@
 
 module Knife
   module Softlayer
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
There is a current bug in `fog-softlayer` gem that prevents the use of this knife provider.

"Cannot modify frozen String" error on Username.

Ref:
https://github.com/softlayer/knife-softlayer/issues/32
https://github.com/fog/fog-softlayer/pull/73/files
